### PR TITLE
랜딩 페이지 기본 작업

### DIFF
--- a/src/components/commons/CommonLayout.tsx
+++ b/src/components/commons/CommonLayout.tsx
@@ -1,0 +1,17 @@
+import { Container } from '@/components/commons/Container';
+import { Header } from '@/components/commons/Header';
+
+import React from 'react';
+
+const headerHeight = 72;
+
+export const CommonLayout: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  return (
+    <Container>
+      <Header h={headerHeight} />
+      {children}
+    </Container>
+  );
+};

--- a/src/components/commons/Flex.tsx
+++ b/src/components/commons/Flex.tsx
@@ -20,4 +20,5 @@ export const Flex = styled.div<{
   justify-content: ${(props) => props.justify || 'flex-start'};
   gap: ${(props) => props.gap || '0'};
   width: ${(props) => props.width ?? 100}%;
+  box-sizing: border-box;
 `;

--- a/src/components/commons/Header.tsx
+++ b/src/components/commons/Header.tsx
@@ -1,0 +1,84 @@
+import { Flex } from '@/components/commons/Flex';
+import { SText } from '@/components/commons/SText';
+import { HeightInNumber } from '@/components/types';
+
+import styled from '@emotion/styled';
+
+const HeaderContainer = styled(Flex)<HeightInNumber>`
+  height: ${(props) => props.h}px;
+  border-radius: 40px;
+  background-color: #333333;
+  align-items: center;
+  padding: 0 53px;
+  margin: 54px 0;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+  border: 1px solid #333333;
+  box-sizing: border-box;
+  justify-content: space-between;
+`;
+
+const ComonSLogo = styled.div`
+  display: flex;
+  font-size: 24px;
+  font-weight: bold;
+  color: white;
+`;
+
+const NavMenu = styled.div`
+  display: flex;
+  gap: 20px;
+  margin-left: 106px;
+
+  a {
+    color: white;
+    text-decoration: none;
+    font-size: 18px;
+    font-weight: 500;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`;
+
+// TODO : 추후 DropDown으로 변경할 것
+const UserMenu = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  white-space: nowrap;
+
+  button {
+    background: none;
+    border: none;
+    color: white;
+    font-size: 16px;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`;
+
+export const Header: React.FC<HeightInNumber> = ({ h }) => {
+  const isLoggedIn = false;
+
+  return (
+    <HeaderContainer h={h}>
+      <Flex>
+        <ComonSLogo>
+          C<SText color={'#8488EC'}>O</SText>M<SText color={'#F15CA7'}>O</SText>
+          N 코몬
+        </ComonSLogo>
+        <NavMenu>
+          <a href="#service">서비스 소개</a>
+          <a href="#team">활동 팀</a>
+        </NavMenu>
+      </Flex>
+      <UserMenu>
+        {isLoggedIn ? <button>로그인</button> : <button>마이 페이지</button>}
+      </UserMenu>
+    </HeaderContainer>
+  );
+};

--- a/src/components/commons/Header.tsx
+++ b/src/components/commons/Header.tsx
@@ -28,6 +28,7 @@ const NavMenu = styled.div`
   display: flex;
   gap: 20px;
   margin-left: 106px;
+  align-items: center;
 
   a {
     color: white;

--- a/src/components/commons/PageSectionHeader.tsx
+++ b/src/components/commons/PageSectionHeader.tsx
@@ -1,0 +1,21 @@
+import { Flex } from '@/components/commons/Flex';
+import { HeightInNumber } from '@/components/types';
+
+import styled from '@emotion/styled';
+
+interface IPageSectionHeader extends HeightInNumber {
+  children: React.ReactNode;
+}
+
+export const PageSectionHeader = styled(Flex)<IPageSectionHeader>`
+  border-radius: 20px;
+  background-color: #f0f1ff;
+  align-items: center;
+  height: ${(props) => props.h ?? 40}px;
+  padding: 0 25px;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 23.87px;
+  text-align: center;
+  color: #333333;
+`;

--- a/src/components/commons/SText.tsx
+++ b/src/components/commons/SText.tsx
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+
+// TODO : background color 필요한지?
+interface TextProps {
+  color?: string;
+  fontSize?: string;
+  fontWeight?: string | number;
+  lineHeight?: string;
+  letterSpacing?: string;
+  textAlign?: React.CSSProperties['textAlign'];
+}
+
+export const SText = styled.div<TextProps>`
+  color: ${(props) => props.color || 'inherit'};
+  font-size: ${(props) => props.fontSize || 'inherit'};
+  font-weight: ${(props) => props.fontWeight || 'inherit'};
+  line-height: ${(props) => props.lineHeight || 'inherit'};
+  letter-spacing: ${(props) => props.letterSpacing || 'inherit'};
+  text-align: ${(props) => props.textAlign || 'inherit'};
+`;

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,0 +1,7 @@
+export interface HeightInNumber {
+  h: number;
+}
+
+export interface HeightInString {
+  h: string;
+}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,9 +1,11 @@
 import { CommonLayout } from '@/components/commons/CommonLayout';
+import { PageSectionHeader } from '@/components/commons/PageSectionHeader';
 
 export const Home = () => {
   return (
     <CommonLayout>
       <div>코드몬스터 랜딩페이지</div>
+      <PageSectionHeader h={40}>타이틀</PageSectionHeader>
     </CommonLayout>
   );
 };

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -4,8 +4,7 @@ import { PageSectionHeader } from '@/components/commons/PageSectionHeader';
 export const Home = () => {
   return (
     <CommonLayout>
-      <div>코드몬스터 랜딩페이지</div>
-      <PageSectionHeader h={40}>타이틀</PageSectionHeader>
+      <PageSectionHeader h={40}>코드몬스터 랜딩페이지</PageSectionHeader>
     </CommonLayout>
   );
 };

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,0 +1,9 @@
+import { CommonLayout } from '@/components/commons/CommonLayout';
+
+export const Home = () => {
+  return (
+    <CommonLayout>
+      <div>코드몬스터 랜딩페이지</div>
+    </CommonLayout>
+  );
+};

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,11 +1,12 @@
 import { createBrowserRouter } from 'react-router-dom';
 
+import { Home } from '@/pages/Home/Home';
 import { PATH } from '@/routes/path';
 
 export const router = createBrowserRouter([
   {
     index: true,
     path: PATH.home,
-    element: <div>홈</div>,
+    element: <Home />,
   },
 ]);


### PR DESCRIPTION
## ✏️ 변경 요약

작업 중 사용할 공통 컴포넌트들을 먼저 추가합니다.

## 🔍 작업 내용

1. 공통 컴포넌트, `SText`, `Header`, `CommonLayout`, `PageSectionHeader` 추가
2. 공통 인터페이스 `HeightInNumber`, `HeightInString` 추가
3. Home 컴포넌트 생성 및 간단 라우팅 적용

SText의 이름은 원래 Text로 하고 싶었으나, 자동 임포트가 안되어 SText로 변경했습니다.
Header 컴포넌트는 추후 변경이 필요합니다. 나중에 작업하겠습니다.

아래는 Home 컴포넌트입니다. 
Home 컴포넌트에서 공통 컴포넌트의 레이아웃 및 사용법을 확인할 수 있습니다.
![image](https://github.com/user-attachments/assets/ac15fdcd-f22f-4a82-bd49-8a5608e29cc7)


