### PR TITLE
fix: 쿠키 객체 빈객체 인지 확인하는 로직 수정

### DIFF
--- a/src/templates/Login/LoginTemplate.tsx
+++ b/src/templates/Login/LoginTemplate.tsx
@@ -29,11 +29,13 @@ export const LoginTemplate = () => {
   const navigate = useNavigate();
   useEffect(() => {
     const cookie = parseCookieAsJson();
-    if (cookie) {
+    if (Object.entries(cookie).length > 0) {
       const at = cookie['access_token'];
-      localStorage.setItem('Authorization', at);
+      if (at) {
+        localStorage.setItem('Authorization', at);
 
-      navigate(isNew(cookie['new']) ? PATH.ENROLL : PATH.HOME);
+        navigate(isNew(cookie['new']) ? PATH.ENROLL : PATH.HOME);
+      }
     }
   }, []);
   return (


### PR DESCRIPTION
## ✏️ 변경 요약

... `Object.entries(cookie).length > 0`를 사용했습니다.

## 🔍 작업 내용

1. 변경
