### PR TITLE
스프린트3 병합

### DIFF
--- a/src/api/apiInstance.ts
+++ b/src/api/apiInstance.ts
@@ -25,6 +25,13 @@ apiInstance.interceptors.request.use(
 apiInstance.interceptors.response.use(
   (response) => response,
   (error: AxiosError<ServerIntendedError>) => {
+    /**
+     * 응답이 401이고, 401의 원인이 access token이 만료된 경우,
+     * refresh token을 통해 access token을 재발급 받은후,
+     * 재발급한 access token을 통해 재요청한다.
+     * access token을 재발급 받을 때, "이전 로그인 정보를 통해 재입장중입니다."라는 느낌의 토스트 메세지를 띄웠으면 좋겠음
+     * 대기시간이 길어지는 이유를 설명하고 싶음.
+     */
     if (error.response) {
       const data = error.response.data;
       const { message } = data;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,6 +1,11 @@
+import { Flex } from '@/components/commons/Flex';
+import { SText } from '@/components/commons/SText';
+import { SimpleLoader } from '@/components/commons/SimpleLoader';
+import { Spacer } from '@/components/commons/Spacer';
 import { MultiSectionLayout } from '@/components/layout/MultiSectionHeader';
 import { SingleSectionLayout } from '@/components/layout/SingleSectionLayout';
 
+import { Suspense, lazy } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
 import { Home } from '@/pages/Home/Home';
@@ -10,8 +15,25 @@ import { PATH } from '@/routes/path';
 import { LoginTemplate } from '@/templates/Login/LoginTemplate';
 import { TeamModificationTemplate } from '@/templates/Team/TeamModificationTemplate';
 import { TeamRegistrationTemplate } from '@/templates/Team/TeamRegistrationTemplate';
-import { EnrollTemplate } from '@/templates/User/EnrollTemplate';
 import { ModificationTemplate } from '@/templates/User/ModificationTemplate';
+
+const LazySkeleton = () => (
+  <Flex align="center" direction="column">
+    <Spacer h={150} />
+    <SimpleLoader />
+    <Spacer h={15} />
+    <SText>로딩중</SText>
+  </Flex>
+);
+
+// TODO: LazySkeleton이 너무 빨리 거둬지면 화면이 그냥 깜빡거리는거 같음. 임시방편으로 최소 딜레이 700ms 설정
+//  다른 방법 사용 찾기가 필수
+const EnrollTemplate = lazy(() => {
+  return Promise.all([
+    import('@/templates/User/EnrollTemplate'),
+    new Promise((resolve) => setTimeout(resolve, 700)),
+  ]).then(([moduleExports]) => moduleExports);
+});
 
 export const router = createBrowserRouter([
   {
@@ -21,11 +43,21 @@ export const router = createBrowserRouter([
   },
   {
     /**
-     * Outlet을 통해 공통된 레이아웃을 공유하는 컴포넌트 끼리 묶어 놓았다.
+     * (11/24) Outlet을 통해 공통된 레이아웃을 공유하는 컴포넌트 끼리 묶어 놓았다.
      * 공통된 레이아웃을 공유한다는 점 외에는 연관이 없는 컴포넌트이다. 순수 디자인을 기준으로 묶음.
      * 뭔가 잘못된 구조에서 동작하게 하려고 몸을 비튼 느낌이 없지 않다.
      * SingleSectionLayout의 PageSectionHeader 컴포넌트의 text-content를 url 별로 다르게 하기 위해 url과 text-content를 손수 매핑함. (path.tsx의 TITLES)
      * 컨텐트를 바꿔가며 사용해야 하지만 굳이 SingleSectionLayout에 포함 시킨 이유는, 나중에 Skeleton UI 만들 때 더 유용할 것으로 판단함.
+     *
+     * (12/04) EnrollTemplate(회원가입 화면)은 사용 빈도가 적어 초기 로드 속도를 향상시키기 위해 동적 임포트 적용
+     * manualChunks 옵션을 통해 동적 임포트 되는 페이지에서 사용되는 상태들 또한 같이 동적 임포트 해야하는지?
+     * 사용되는 상태는 동적 임포트 하지 않고 페이지만 동적으로 나눈다면, 크게 의미가 있는지?
+     * EnrollTemplate을 동적으로 임포트한다면, 상태 파일을 공유하는 ModificationTemplate는 어떻게 해야하는지?
+     * 그냥 form 관련 페이지들과 상태를 하나의 청크로 묶는게 좋을지? 코드 상으론 깔끔해 보이지만 각 페이지 마다 사용 목적과 시점이 다 다르긴함.
+     * 고민중
+     *
+     * 그런데, 애초에 form 관련 페이지가 다른 페이지에 비해 사용 빈도가 낮으니
+     * form 관련 페이지의 상태는 그냥 uncontrolled 방식으로 만들었으면 청크만 분리하면 되기 때문에 코드스플리팅이 더 쉬웠을듯함.
      */
     element: <SingleSectionLayout />,
     children: [
@@ -35,7 +67,11 @@ export const router = createBrowserRouter([
       },
       {
         path: PATH.ENROLL,
-        element: <EnrollTemplate />,
+        element: (
+          <Suspense fallback={<LazySkeleton />}>
+            <EnrollTemplate />
+          </Suspense>
+        ),
       },
       {
         path: PATH.PROFILE,

--- a/src/templates/User/EnrollTemplate.tsx
+++ b/src/templates/User/EnrollTemplate.tsx
@@ -7,7 +7,7 @@ import { Fragment, useEffect } from 'react';
 
 import { EnrollForm } from '@/templates/User/EnrollForm';
 
-export const EnrollTemplate = () => {
+const EnrollTemplate = () => {
   useEffect(() => {
     handleCookieOnRedirect();
   }, []);
@@ -21,3 +21,5 @@ export const EnrollTemplate = () => {
     </Fragment>
   );
 };
+
+export default EnrollTemplate;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,19 @@ export default defineConfig({
       },
     }),
   ],
+  build: {
+    // rollupOptions의 output을 사용하면 번들이 완성 됐을 때, 주석을 제거하지만, terserOptions를 사용하면 압축단계에서 주석을 제거함
+    // 개발 일지 관련 주석 제거가 목적이므로 해당 옵션을 사용해야 빌드 시간이 단축 될 것으로 판단됨 (실험은 안해봄)
+    terserOptions: {
+      format: {
+        comments: false,
+      },
+      compress: {
+        drop_console: true,
+        drop_debugger: true,
+      },
+    },
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## ✏️ 변경 요약

사용 빈도가 적은 컴포넌트를 다른 청크로 뺐습니다.
로그인 로직 변경 (리프레쉬 토큰 적용 및 액세스 토큰 발급 자동화)은 빠른 적용이 필요했어서 main 브렌치에서 작업했습니다..
vite.config.ts를 변경해 필드 파일에 주석과 console.log, debug를 포함 시키지 않도록 했습니다.

## 🔍 작업 내용

1. EnrollTemplate에 lazy load 적용
2. vite.config.ts의 terserOptions 옵션 변경

## 📌 관련된 이슈


## 📢 기타
