### PR TITLE
이미지 압축 기능 추가

### DIFF
--- a/src/components/commons/Form/ComonImageInput.tsx
+++ b/src/components/commons/Form/ComonImageInput.tsx
@@ -114,7 +114,7 @@ export const ComonImageInput = () => {
         workerRef.current.onmessage = (e) => {
           const { compressedImage, error = undefined } = e.data;
           if (compressedImage && !error) {
-            console.log('after: ', compressedImage.size);
+            console.log('after: ', readableBytes(compressedImage.size));
             setImage(compressedImage);
             return;
           }
@@ -128,7 +128,7 @@ export const ComonImageInput = () => {
 
       reader.onload = (e: ProgressEvent<FileReader>) => {
         const worker = workerRef.current;
-        console.log('before: ', file.size);
+        console.log('before: ', readableBytes(file.size));
         worker?.postMessage({
           src: e?.target?.result,
           fileType: file.type,
@@ -186,4 +186,11 @@ export const ComonImageInput = () => {
       </SideContainer>
     </Flex>
   );
+};
+
+const readableBytes = (bytes: number) => {
+  const i = Math.floor(Math.log(bytes) / Math.log(1024)),
+    sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+  return (bytes / Math.pow(1024, i)).toFixed(2) + ' ' + sizes[i];
 };

--- a/src/components/commons/Form/ComonImageInput.tsx
+++ b/src/components/commons/Form/ComonImageInput.tsx
@@ -1,5 +1,6 @@
 import { Flex } from '@/components/commons/Flex';
 import { SText } from '@/components/commons/SText';
+import { SimpleLoader } from '@/components/commons/SimpleLoader';
 import { HeightInNumber } from '@/components/types';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -171,8 +172,13 @@ export const ComonImageInput = () => {
   return (
     <Flex gap={'17px'}>
       <ImageContainer h={200} onDragOver={handleDragOver} onDrop={handleDrop}>
-        {imageStr && <PreviewImage src={imageStr} alt="Uploaded preview" />}
-        {!imageStr && <PlaceholderText>이미지를 드래그하세요</PlaceholderText>}
+        {image && imageStr && (
+          <PreviewImage src={imageStr} alt="Uploaded preview" />
+        )}
+        {image && !imageStr && <SimpleLoader />}
+        {!image && !imageStr && (
+          <PlaceholderText>이미지를 드래그하세요</PlaceholderText>
+        )}
       </ImageContainer>
       <SideContainer h={200}>
         <ImageRestrictionNotice />

--- a/src/components/commons/Form/ComonImageInput.tsx
+++ b/src/components/commons/Form/ComonImageInput.tsx
@@ -115,10 +115,11 @@ export const ComonImageInput = () => {
           const { compressedImage, error = undefined } = e.data;
           if (compressedImage && !error) {
             console.log('after: ', readableBytes(compressedImage.size));
+
             setImage(compressedImage);
             return;
           }
-          console.error(error);
+          console.error('이미지 압축에 실패했습니다.', error);
           // 그래도 일단 돌아는 가야 하지 않을까
           setImage(file);
         };

--- a/src/workers/imageCompressor.ts
+++ b/src/workers/imageCompressor.ts
@@ -1,5 +1,6 @@
-/*
-  JPG랑 PNG만 압축가능한데 다른 확장자도 필요하다면 그냥 browser-image-compression 쓰는게 나을듯함
+/**
+  (12/06) JPG만 압축가능한데 다른 확장자도 필요하다면 그냥 browser-image-compression 쓰는게 나을듯함
+  그래도 PNG까지는 해보고 싶음
  */
 function compressImage(
   image: ImageBitmap,
@@ -19,8 +20,15 @@ function compressImage(
 
     const compressOptions = {
       type: fileType,
-      quality: fileType === 'image/jpeg' ? quality : undefined,
+      // quality: fileType === 'image/jpeg' ? quality : undefined,
+      quality: quality,
     };
+
+    // if (fileType === 'image/png') {
+    //   // const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    //   const cvs = ctx.canvas;
+    //
+    // }
 
     canvas
       .convertToBlob(compressOptions)

--- a/src/workers/imageCompressor.ts
+++ b/src/workers/imageCompressor.ts
@@ -4,7 +4,12 @@
   다른 레퍼런스들 처럼 그냥 Canvas를 사용해봤는데 이거로 해도 PNG는 그냥 크기가 커짐.
   그래도 PNG까지는 해보고 싶음.
   다른 확장자도 필요하다면 그냥 browser-image-compression 쓰는게 나을듯함
+
+  (12/06) PNG의 무손실 압축을 구현할 수 없어서 PNG면 JPG로 변환해서 압축후 그냥 PNG로 변환한다.
+  진짜 돌아만 가는 코드지만 압축은 된다.
+  여기서 더 개선이나 추가 기능이 필요하다면 그냥 brower-image-compression 써야함.
  */
+
 function compressImage(
   image: ImageBitmap,
   fileType: string,
@@ -19,19 +24,27 @@ function compressImage(
       return;
     }
 
+    if (fileType === 'image/png') {
+      const imageData = ctx.getImageData(0, 0, image.width, image.height);
+      const data = imageData.data;
+      for (let i = 0; i < data.length; i += 4) {
+        if (data[i] === 0 && data[i + 1] === 0 && data[i + 2] === 0) {
+          data[i] = 255;
+          data[i + 1] = 255;
+          data[i + 2] = 255;
+          data[i + 3] = 255;
+        }
+      }
+
+      ctx.putImageData(imageData, 0, 0);
+    }
+
     ctx.drawImage(image, 0, 0);
 
     const compressOptions = {
-      type: fileType,
-      // quality: fileType === 'image/jpeg' ? quality : undefined,
-      quality: quality,
+      type: 'image/jpeg',
+      quality: fileType === 'image/jpeg' ? quality : undefined,
     };
-
-    // if (fileType === 'image/png') {
-    //   // const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
-    //   const cvs = ctx.canvas;
-    //
-    // }
 
     canvas
       .convertToBlob(compressOptions)
@@ -73,3 +86,86 @@ self.onmessage = (e) => {
       self.postMessage({ error: 'Image Compression failed: ' + error });
     });
 };
+
+/*
+  이거 그레이 스케일됨
+ */
+// function png32bitColorTo8bitColor(data: Uint8ClampedArray, canvas: OffscreenCanvas) {
+//   // Create a simple 256 color palette (you can customize this if necessary)
+//   const colorPalette: number[][] = [];
+//   for (let i = 0; i < 256; i++) {
+//     const r = (i * 255) / 255;
+//     const g = (i * 255) / 255;
+//     const b = (i * 255) / 255;
+//     colorPalette.push([r, g, b]);
+//   }
+//
+//   // Function to find the closest color from the palette
+//   function findClosestColor(r: number, g: number, b: number): number[] {
+//     let closestColor = colorPalette[0];
+//     let minDistance = Infinity;
+//
+//     for (let i = 0; i < colorPalette.length; i++) {
+//       const [cr, cg, cb] = colorPalette[i];
+//       // Calculate the Euclidean distance between the current pixel and palette color
+//       const distance = Math.sqrt((r - cr) ** 2 + (g - cg) ** 2 + (b - cb) ** 2);
+//       if (distance < minDistance) {
+//         minDistance = distance;
+//         closestColor = colorPalette[i];
+//       }
+//     }
+//
+//     return closestColor;
+//   }
+//
+//   // Floyd-Steinberg dithering
+//   for (let y = 0; y < canvas.height; y++) {
+//     for (let x = 0; x < canvas.width; x++) {
+//       const i = (y * canvas.width + x) * 4;
+//       const r = data[i]; // Red channel
+//       const g = data[i + 1]; // Green channel
+//       const b = data[i + 2]; // Blue channel
+//
+//       // Find the closest color in the palette
+//       const [closestR, closestG, closestB] = findClosestColor(r, g, b);
+//
+//       // Set the pixel color to the closest palette color
+//       data[i] = closestR;
+//       data[i + 1] = closestG;
+//       data[i + 2] = closestB;
+//
+//       // Calculate the error between the original color and the quantized color
+//       const errorR = r - closestR;
+//       const errorG = g - closestG;
+//       const errorB = b - closestB;
+//
+//       // Spread the error to neighboring pixels using Floyd-Steinberg dithering
+//       if (x + 1 < canvas.width) {
+//         const i1 = (y * canvas.width + (x + 1)) * 4;
+//         data[i1] += (errorR * 7) / 16;
+//         data[i1 + 1] += (errorG * 7) / 16;
+//         data[i1 + 2] += (errorB * 7) / 16;
+//       }
+//
+//       if (y + 1 < canvas.height) {
+//         if (x > 0) {
+//           const i2 = ((y + 1) * canvas.width + (x - 1)) * 4;
+//           data[i2] += (errorR * 3) / 16;
+//           data[i2 + 1] += (errorG * 3) / 16;
+//           data[i2 + 2] += (errorB * 3) / 16;
+//         }
+//         const i3 = ((y + 1) * canvas.width + x) * 4;
+//         data[i3] += (errorR * 5) / 16;
+//         data[i3 + 1] += (errorG * 5) / 16;
+//         data[i3 + 2] += (errorB * 5) / 16;
+//
+//         if (x + 1 < canvas.width) {
+//           const i4 = ((y + 1) * canvas.width + (x + 1)) * 4;
+//           data[i4] += errorR / 16;
+//           data[i4 + 1] += errorG / 16;
+//           data[i4 + 2] += errorB / 16;
+//         }
+//       }
+//     }
+//   }
+// }

--- a/src/workers/imageCompressor.ts
+++ b/src/workers/imageCompressor.ts
@@ -1,6 +1,9 @@
 /**
-  (12/06) JPG만 압축가능한데 다른 확장자도 필요하다면 그냥 browser-image-compression 쓰는게 나을듯함
-  그래도 PNG까지는 해보고 싶음
+  (12/06) JPG만 압축가능한데 JPG는 압축 잘 되는데 PNG는 오히려 크기가 커진다.
+  OffscreenCanvas를 처음써봐서 잘 모르지만, OffscreenCanvas가 문제인가 싶어서
+  다른 레퍼런스들 처럼 그냥 Canvas를 사용해봤는데 이거로 해도 PNG는 그냥 크기가 커짐.
+  그래도 PNG까지는 해보고 싶음.
+  다른 확장자도 필요하다면 그냥 browser-image-compression 쓰는게 나을듯함
  */
 function compressImage(
   image: ImageBitmap,

--- a/src/workers/imageCompressor.ts
+++ b/src/workers/imageCompressor.ts
@@ -1,0 +1,64 @@
+/*
+  JPG랑 PNG만 압축가능한데 다른 확장자도 필요하다면 그냥 browser-image-compression 쓰는게 나을듯함
+ */
+function compressImage(
+  image: ImageBitmap,
+  fileType: string,
+  fileName: string,
+  quality?: number
+): Promise<File> {
+  return new Promise((resolve, reject) => {
+    const canvas = new OffscreenCanvas(image.width, image.height);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      reject('Failed to create canvas context');
+      return;
+    }
+
+    ctx.drawImage(image, 0, 0);
+
+    const compressOptions = {
+      type: fileType,
+      quality: fileType === 'image/jpeg' ? quality : undefined,
+    };
+
+    canvas
+      .convertToBlob(compressOptions)
+      .then((blob) => {
+        const fileLastModified = Date.now();
+        const compressedFile = new File([blob], fileName, {
+          type: fileType,
+          lastModified: fileLastModified,
+        });
+        resolve(compressedFile);
+      })
+      .catch(reject);
+  });
+}
+
+self.onmessage = (e) => {
+  const { src, fileType, fileName, quality } = e.data;
+  /*
+    worker는 Web API에 접근할 수 없어서,
+    const image = new Image() <- 이게 안되서 이렇게 해야함
+    그냥 이미지 만드는 작업임
+   */
+  const imagePromise = fetch(src)
+    .then((res) => res.blob())
+    .then((blob) => createImageBitmap(blob))
+    .catch((error) => {
+      self.postMessage({ error: 'Image Creation failed: ' + error });
+      return Promise.reject(error);
+    });
+
+  imagePromise
+    .then((imageBitmap) =>
+      compressImage(imageBitmap, fileType, fileName, quality)
+    )
+    .then((compressedImage) => {
+      self.postMessage({ compressedImage: compressedImage });
+    })
+    .catch((error) => {
+      self.postMessage({ error: 'Image Compression failed: ' + error });
+    });
+};


### PR DESCRIPTION
## ✏️ 변경 요약

사용자로부터 이미지를 받은 경우, worker를 통해 이미지를 압축합니다.
이미지 압축은 JPG와 PNG만 지원합니다.
이미지 압축 관련하여 기능 개선이나 추가가 필요한 상황에서는 그냥 `browser-image-compression`을 사용하는 게 좋을 듯 합니다.

## 🔍 작업 내용

1. imageCompressor 추가

## 📌 관련된 이슈

## 📢 기타
