### PR TITLE
구글 태그 매니저 스크립트 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,15 @@
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-P8PTWPDW');</script>
     <!-- End Google Tag Manager -->
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-RVSHBSJHTR"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-RVSHBSJHTR');
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>COMON</title>
   </head>

--- a/src/components/commons/Header.tsx
+++ b/src/components/commons/Header.tsx
@@ -142,6 +142,7 @@ export const Header: React.FC<HeightInNumber> = ({ h }) => {
       .then(() => {
         sessionStorage.removeItem('Authorization');
         alert('로그아웃 되었습니다!');
+        navigate(PATH.HOME);
         window.location.reload();
       })
       .catch((err) => console.error(err));

--- a/src/components/features/TeamDashboard/ArticleDetail.tsx
+++ b/src/components/features/TeamDashboard/ArticleDetail.tsx
@@ -30,6 +30,9 @@ export const ArticleDetail: React.FC<ArticleDetailProps> = ({
         : data?.articleBody,
     [data]
   );
+
+  console.error('ad', article);
+
   return (
     <Box width="100%" padding="30px 40px">
       <Flex direction="column" justify="center" align="flex-start">
@@ -84,6 +87,7 @@ export const ArticleDetail: React.FC<ArticleDetailProps> = ({
           </SText>
         </Flex>
         <Spacer h={36} />
+
         <div
           dangerouslySetInnerHTML={{
             __html: article,

--- a/src/components/layout/CommonLayout.tsx
+++ b/src/components/layout/CommonLayout.tsx
@@ -13,8 +13,9 @@ export const CommonLayout: React.FC<{
 
   useLayoutEffect(() => {
     let prev: string | null = null;
-    if (prev !== location.pathname) {
-      prev = location.pathname;
+    const currPath = location.pathname.split('/')[1];
+    if (prev !== currPath) {
+      prev = currPath;
       document.documentElement.scrollTo({
         top: 0,
         left: 0,

--- a/src/pages/TeamAdmin/TeamAdmin.tsx
+++ b/src/pages/TeamAdmin/TeamAdmin.tsx
@@ -159,6 +159,7 @@ const CalendarSection = styled.section`
   background-color: #f8f8ff;
   border-radius: 20px;
   padding: 20px 36px 40px 36px;
+  margin-bottom: 100px;
 `;
 
 export const TeamAdmin = () => {


### PR DESCRIPTION
## ✏️ 변경 요약

...

## 🔍 작업 내용

1. 로그아웃 시 홈으로 이동시킨 후 리프레쉬
2. 스크롤 상단으로 끌어올리는 기준 변경 
3. 팀장 페이지 하단 여백 추가
4. 구글 태그 매니저 스크립트 추가

## 📌 관련된 이슈

...

## 📢 기타
