### PR TITLE
게시글 링크, 코드블럭 단축키 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.13.5",
         "@emotion/styled": "^11.13.5",
+        "@lexical/code": "^0.21.0",
         "@lexical/html": "^0.21.0",
         "@lexical/link": "^0.21.0",
         "@lexical/react": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/react": "^11.13.5",
     "@emotion/styled": "^11.13.5",
+    "@lexical/code": "^0.21.0",
     "@lexical/html": "^0.21.0",
     "@lexical/link": "^0.21.0",
     "@lexical/react": "^0.21.0",

--- a/src/components/features/Post/PostEditor.tsx
+++ b/src/components/features/Post/PostEditor.tsx
@@ -1,17 +1,27 @@
 import { viewStyle } from '@/utils/viewStyle';
 
 import { ImageNode } from '@/components/features/Post/nodes/ImageNode';
+import { CodeActionPlugin } from '@/components/features/Post/plugins/CodeActionPlugin';
 import { FloatingLinkEditorPlugin } from '@/components/features/Post/plugins/FloatingLinkEditorPlugin';
 import { GrabContentPlugin } from '@/components/features/Post/plugins/GrabContentPlugin';
+import { HighlightCodePlugin } from '@/components/features/Post/plugins/HighlightCodePlugin';
 import { ImagePlugin } from '@/components/features/Post/plugins/ImagePlugin';
 import { InitContentPlugin } from '@/components/features/Post/plugins/InitContentPlugin';
 import { MaxIndentPlugin } from '@/components/features/Post/plugins/MaxIndentPlugin';
 import { ToolbarPlugin } from '@/components/features/Post/plugins/ToolbarPlugin';
 import { SHORTCUTS } from '@/components/features/Post/plugins/markdownShortcuts';
 
-import { ChangeEvent, forwardRef, memo, useCallback, useState } from 'react';
+import {
+  ChangeEvent,
+  Fragment,
+  forwardRef,
+  memo,
+  useCallback,
+  useState,
+} from 'react';
 
 import styled from '@emotion/styled';
+import { CodeHighlightNode, CodeNode } from '@lexical/code';
 import { AutoLinkNode, LinkNode } from '@lexical/link';
 import { ListItemNode, ListNode } from '@lexical/list';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
@@ -50,6 +60,39 @@ const editorTheme = {
     underlineStrikethrough: 'editor-text-underlineStrikethrough',
     code: 'editor-text-code',
   },
+  code: 'codeblock',
+  codeHighlight: {
+    atrule: 'tokenAttr',
+    attr: 'tokenAttr',
+    boolean: 'tokenProperty',
+    builtin: 'tokenSelector',
+    cdata: 'tokenComment',
+    char: 'tokenSelector',
+    class: 'tokenFunction',
+    'class-name': 'tokenFunction',
+    comment: 'tokenComment',
+    constant: 'tokenProperty',
+    deleted: 'tokenProperty',
+    doctype: 'tokenComment',
+    entity: 'tokenOperator',
+    function: 'tokenFunction',
+    important: 'tokenVariable',
+    inserted: 'tokenSelector',
+    keyword: 'tokenAttr',
+    namespace: 'tokenVariable',
+    number: 'tokenProperty',
+    operator: 'tokenOperator',
+    prolog: 'tokenComment',
+    property: 'tokenProperty',
+    punctuation: 'tokenPunctuation',
+    regex: 'tokenVariable',
+    selector: 'tokenSelector',
+    string: 'tokenSelector',
+    symbol: 'tokenProperty',
+    tag: 'tokenProperty',
+    url: 'tokenOperator',
+    variable: 'tokenVariable',
+  },
 };
 
 const initialConfig = {
@@ -63,6 +106,8 @@ const initialConfig = {
     QuoteNode,
     ListNode,
     ListItemNode,
+    CodeNode,
+    CodeHighlightNode,
   ],
   editorState: undefined,
   onError,
@@ -203,11 +248,14 @@ const PostEditor: React.FC<{
             }
           />
           {floatingAnchorElem && (
-            <FloatingLinkEditorPlugin
-              anchorElem={floatingAnchorElem}
-              isLinkEditMode={isLinkEditMode}
-              setIsLinkEditMode={setIsLinkEditMode}
-            />
+            <Fragment>
+              <FloatingLinkEditorPlugin
+                anchorElem={floatingAnchorElem}
+                isLinkEditMode={isLinkEditMode}
+                setIsLinkEditMode={setIsLinkEditMode}
+              />
+              <CodeActionPlugin anchorElem={floatingAnchorElem} />
+            </Fragment>
           )}
           <ImagePlugin />
           <LinkPlugin />
@@ -220,6 +268,7 @@ const PostEditor: React.FC<{
           <ListPlugin />
           <TabIndentationPlugin />
           <MaxIndentPlugin />
+          <HighlightCodePlugin />
         </PostContainer>
       </PostWrap>
     </LexicalComposer>

--- a/src/components/features/Post/plugins/CodeActionPlugin.tsx
+++ b/src/components/features/Post/plugins/CodeActionPlugin.tsx
@@ -1,0 +1,297 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { $isCodeNode, CodeNode, getLanguageFriendlyName } from '@lexical/code';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import {
+  $getNearestNodeFromDOMNode,
+  $getSelection,
+  $setSelection,
+  LexicalEditor,
+  isHTMLElement,
+} from 'lexical';
+
+const CODE_PADDING = 8;
+
+interface Position {
+  top: string;
+  right: string;
+}
+
+const debounce = <T extends (...args: any[]) => void>(
+  func: T,
+  wait: number,
+  options: { maxWait?: number } = {}
+) => {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  // @ts-ignore
+  let lastCallTime: number | null = null;
+  let lastInvokeTime: number | null = null;
+
+  const { maxWait } = options;
+
+  const invokeFunc = (args: Parameters<T>) => {
+    func(...args);
+    lastInvokeTime = Date.now();
+  };
+
+  const debounced = (...args: Parameters<T>) => {
+    const now = Date.now();
+
+    if (!lastInvokeTime) {
+      lastInvokeTime = now;
+    }
+
+    if (maxWait && now - lastInvokeTime >= maxWait) {
+      if (timeout) clearTimeout(timeout);
+      invokeFunc(args);
+      lastCallTime = null;
+      timeout = null;
+      return;
+    }
+
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
+    timeout = setTimeout(() => {
+      invokeFunc(args);
+      lastCallTime = null;
+      timeout = null;
+    }, wait);
+
+    lastCallTime = now;
+  };
+
+  debounced.cancel = () => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = null;
+    lastCallTime = null;
+  };
+
+  return debounced;
+};
+
+const useDebounce = <T extends (...args: never[]) => void>(
+  fn: T,
+  ms: number,
+  maxWait?: number
+) => {
+  const funcRef = useRef<T | null>(null);
+  funcRef.current = fn;
+
+  return useMemo(
+    () =>
+      debounce(
+        (...args: Parameters<T>) => {
+          if (funcRef.current) {
+            funcRef.current(...args);
+          }
+        },
+        ms,
+        { maxWait }
+      ),
+    [ms, maxWait]
+  );
+};
+
+interface Props {
+  editor: LexicalEditor;
+  getCodeDOMNode: () => HTMLElement | null;
+}
+
+const CopyButton = ({ editor, getCodeDOMNode }: Props) => {
+  const [isCopyCompleted, setCopyCompleted] = useState<boolean>(false);
+
+  const removeSuccess = useDebounce(() => {
+    setCopyCompleted(false);
+  }, 3000);
+
+  const handleClick = async (): Promise<void> => {
+    const codeDOMNode = getCodeDOMNode();
+
+    if (!codeDOMNode) {
+      return;
+    }
+
+    let content = '';
+
+    editor.update(() => {
+      const codeNode = $getNearestNodeFromDOMNode(codeDOMNode);
+
+      if ($isCodeNode(codeNode)) {
+        content = codeNode.getTextContent();
+      }
+
+      const selection = $getSelection();
+      $setSelection(selection);
+    });
+
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopyCompleted(true);
+      removeSuccess();
+    } catch (err) {
+      console.error('Failed to copy: ', err);
+    }
+  };
+
+  return (
+    <button className="menu-item" onClick={handleClick} aria-label="copy">
+      {isCopyCompleted ? '복사완료!' : '복사하기'}
+    </button>
+  );
+};
+
+const CodeActionMenuContainer = ({
+  anchorElem,
+}: {
+  anchorElem: HTMLElement;
+}): JSX.Element => {
+  const [editor] = useLexicalComposerContext();
+
+  const [lang, setLang] = useState('');
+  const [isShown, setShown] = useState<boolean>(false);
+  const [shouldListenMouseMove, setShouldListenMouseMove] =
+    useState<boolean>(false);
+  const [position, setPosition] = useState<Position>({
+    right: '0',
+    top: '0',
+  });
+  const codeSetRef = useRef<Set<string>>(new Set());
+  const codeDOMNodeRef = useRef<HTMLElement | null>(null);
+
+  const getCodeDOMNode = (): HTMLElement | null => {
+    return codeDOMNodeRef.current;
+  };
+
+  const debouncedOnMouseMove = useDebounce(
+    (event: MouseEvent) => {
+      const { codeDOMNode, isOutside } = getMouseInfo(event);
+      if (isOutside) {
+        setShown(false);
+        return;
+      }
+
+      if (!codeDOMNode) {
+        return;
+      }
+
+      codeDOMNodeRef.current = codeDOMNode;
+
+      let codeNode: CodeNode | null = null;
+      let _lang = '';
+
+      editor.update(() => {
+        const maybeCodeNode = $getNearestNodeFromDOMNode(codeDOMNode);
+
+        if ($isCodeNode(maybeCodeNode)) {
+          codeNode = maybeCodeNode;
+          _lang = codeNode.getLanguage() || '';
+        }
+      });
+      if (codeNode) {
+        const { y: editorElemY, right: editorElemRight } =
+          anchorElem.getBoundingClientRect();
+        const { y, right } = codeDOMNode.getBoundingClientRect();
+        setLang(_lang);
+        setShown(true);
+        const wtf = {
+          right: `${editorElemRight - right + CODE_PADDING}px`,
+          top: `${y - editorElemY}px`,
+        };
+        setPosition(wtf);
+      }
+    },
+    50,
+    1000
+  );
+
+  useEffect(() => {
+    if (!shouldListenMouseMove) {
+      return;
+    }
+
+    document.addEventListener('mousemove', debouncedOnMouseMove);
+
+    return () => {
+      setShown(false);
+      debouncedOnMouseMove.cancel();
+      document.removeEventListener('mousemove', debouncedOnMouseMove);
+    };
+  }, [shouldListenMouseMove, debouncedOnMouseMove]);
+
+  useEffect(() => {
+    return editor.registerMutationListener(
+      CodeNode,
+      (mutations) => {
+        editor.getEditorState().read(() => {
+          for (const [key, type] of mutations) {
+            switch (type) {
+              case 'created':
+                codeSetRef.current.add(key);
+                break;
+
+              case 'destroyed':
+                codeSetRef.current.delete(key);
+                break;
+
+              default:
+                break;
+            }
+          }
+        });
+        setShouldListenMouseMove(codeSetRef.current.size > 0);
+      },
+      { skipInitialization: false }
+    );
+  }, [editor]);
+
+  const codeFriendlyName = getLanguageFriendlyName(lang);
+
+  return (
+    <>
+      {isShown ? (
+        <div className="code-action-menu-container" style={{ ...position }}>
+          <div className="code-highlight-language">{codeFriendlyName}</div>
+          <CopyButton editor={editor} getCodeDOMNode={getCodeDOMNode} />
+        </div>
+      ) : null}
+    </>
+  );
+};
+
+const getMouseInfo = (
+  event: MouseEvent
+): {
+  codeDOMNode: HTMLElement | null;
+  isOutside: boolean;
+} => {
+  const target = event.target;
+
+  // @ts-ignore
+  if (isHTMLElement(target)) {
+    const codeDOMNode = target.closest<HTMLElement>('code.codeblock');
+    const isOutside = !(
+      codeDOMNode ||
+      target.closest<HTMLElement>('div.code-action-menu-container')
+    );
+
+    return { codeDOMNode, isOutside };
+  } else {
+    return { codeDOMNode: null, isOutside: true };
+  }
+};
+
+export const CodeActionPlugin = ({
+  anchorElem = document.body,
+}: {
+  anchorElem?: HTMLElement;
+}): React.ReactPortal | null => {
+  return createPortal(
+    <CodeActionMenuContainer anchorElem={anchorElem} />,
+    anchorElem
+  );
+};

--- a/src/components/features/Post/plugins/CodeActionPlugin.tsx
+++ b/src/components/features/Post/plugins/CodeActionPlugin.tsx
@@ -18,15 +18,17 @@ interface Position {
   right: string;
 }
 
-const debounce = <T extends (...args: any[]) => void>(
+type AnyFunction = (...args: unknown[]) => unknown;
+
+const debounce = <T extends AnyFunction>(
   func: T,
   wait: number,
   options: { maxWait?: number } = {}
 ) => {
   let timeout: ReturnType<typeof setTimeout> | null = null;
-  // @ts-expect-error
   let lastCallTime: number | null = null;
   let lastInvokeTime: number | null = null;
+  console.log(lastCallTime);
 
   const { maxWait } = options;
 
@@ -84,9 +86,9 @@ const useDebounce = <T extends (...args: never[]) => void>(
   return useMemo(
     () =>
       debounce(
-        (...args: Parameters<T>) => {
+        (...args) => {
           if (funcRef.current) {
-            funcRef.current(...args);
+            funcRef.current(...(args as Parameters<T>));
           }
         },
         ms,

--- a/src/components/features/Post/plugins/CodeActionPlugin.tsx
+++ b/src/components/features/Post/plugins/CodeActionPlugin.tsx
@@ -24,7 +24,7 @@ const debounce = <T extends (...args: any[]) => void>(
   options: { maxWait?: number } = {}
 ) => {
   let timeout: ReturnType<typeof setTimeout> | null = null;
-  // @ts-ignore
+  // @ts-expect-error
   let lastCallTime: number | null = null;
   let lastInvokeTime: number | null = null;
 
@@ -70,7 +70,6 @@ const debounce = <T extends (...args: any[]) => void>(
     timeout = null;
     lastCallTime = null;
   };
-
   return debounced;
 };
 
@@ -149,7 +148,7 @@ const CodeActionMenuContainer = ({
   anchorElem,
 }: {
   anchorElem: HTMLElement;
-}): JSX.Element => {
+}) => {
   const [editor] = useLexicalComposerContext();
 
   const [lang, setLang] = useState('');
@@ -271,8 +270,7 @@ const getMouseInfo = (
 } => {
   const target = event.target;
 
-  // @ts-ignore
-  if (isHTMLElement(target)) {
+  if (target && isHTMLElement(target)) {
     const codeDOMNode = target.closest<HTMLElement>('code.codeblock');
     const isOutside = !(
       codeDOMNode ||

--- a/src/components/features/Post/plugins/HighlightCodePlugin.ts
+++ b/src/components/features/Post/plugins/HighlightCodePlugin.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+
+import { registerCodeHighlighting } from '@lexical/code';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+
+export const HighlightCodePlugin = () => {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return registerCodeHighlighting(editor);
+  }, [editor]);
+
+  return null;
+};

--- a/src/components/features/Post/utils.ts
+++ b/src/components/features/Post/utils.ts
@@ -3,7 +3,9 @@ import { ImagePayload } from '@/components/features/Post/nodes/ImageNode';
 import { $isAtNodeEnd } from '@lexical/selection';
 import {
   ElementNode,
+  Klass,
   LexicalCommand,
+  LexicalNode,
   RangeSelection,
   TextNode,
   createCommand,
@@ -70,3 +72,42 @@ export const setFloatingElemPositionForLinkEditor = (
   floatingElem.style.opacity = '1';
   floatingElem.style.transform = `translate(${left}px, ${top}px)`;
 };
+
+export type TextMatchTransformer = Readonly<{
+  dependencies: Array<Klass<LexicalNode>>;
+  /**
+   * Determines how a node should be exported to markdown
+   */
+  export?: (
+    node: LexicalNode,
+    exportChildren: (node: ElementNode) => string,
+    exportFormat: (node: TextNode, textContent: string) => string
+  ) => string | null;
+  /**
+   * This regex determines what text is matched during markdown imports
+   */
+  importRegExp?: RegExp;
+  /**
+   * This regex determines what text is matched for markdown shortcuts while typing in the editor
+   */
+  regExp: RegExp;
+  /**
+   * Determines how the matched markdown text should be transformed into a node during the markdown import process
+   */
+  replace?: (node: TextNode, match: RegExpMatchArray) => void;
+  /**
+   * For import operations, this function can be used to determine the end index of the match, after `importRegExp` has matched.
+   * Without this function, the end index will be determined by the length of the match from `importRegExp`. Manually determining the end index can be useful if
+   * the match from `importRegExp` is not the entire text content of the node. That way, `importRegExp` can be used to match only the start of the node, and `getEndIndex`
+   * can be used to match the end of the node.
+   *
+   * @returns The end index of the match, or false if the match was unsuccessful and a different transformer should be tried.
+   */
+  getEndIndex?: (node: TextNode, match: RegExpMatchArray) => number | false;
+  /**
+   * Single character that allows the transformer to trigger when typed in the editor. This does not affect markdown imports outside of the markdown shortcut plugin.
+   * If the trigger is matched, the `regExp` will be used to match the text in the second step.
+   */
+  trigger?: string;
+  type: 'text-match';
+}>;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -34,7 +34,7 @@ const useAuth = () => {
   };
 };
 
-export const PrivateRoute = ({ children }: { children: React.ReactNode }) => {
+const PrivateRoute = ({ children }: { children: React.ReactNode }) => {
   const { isAuthenticated } = useAuth();
   const location = useLocation();
 

--- a/src/utils/viewStyle.ts
+++ b/src/utils/viewStyle.ts
@@ -83,6 +83,45 @@ export const viewStyle = `& {
     .nested {
       list-style-type: none;
     }
+    
+    
+.code-action-menu-container {
+    height: 36px;
+    font-size: 10px;
+    color: rgba(0, 0, 0, 0.5);
+    position: absolute;
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    user-select: none;
+}
+
+.code-action-menu-container .code-highlight-language {
+    margin-right: 4px;
+}
+
+.code-action-menu-container button.menu-item {
+    border: 1px solid transparent;
+    border-radius: 4px;
+    padding: 4px;
+    background: none;
+    cursor: pointer;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    color: rgba(0, 0, 0, 0.5);
+    text-transform: uppercase;
+}
+
+.code-action-menu-container button.menu-item:hover {
+    border: 1px solid rgba(0, 0, 0, 0.3);
+    opacity: 0.9;
+}
+
+.code-action-menu-container button.menu-item:active {
+    background-color: rgba(223, 232, 250);
+    border: 1px solid rgba(0, 0, 0, 0.45);
+}
   }
 
   & ul {
@@ -131,4 +170,58 @@ export const viewStyle = `& {
 
   & ol ol ol ol ol ol {
     list-style-type: lower-roman;
-  }`;
+  }
+  
+.codeblock {
+    background-color: #f8f6f2;
+    font-family: Menlo, Consolas, Monaco, monospace;
+    display: block;
+    padding: 8px 8px 8px 52px;
+    line-height: 1.53;
+    font-size: 16px;
+    margin: 8px 0;
+    overflow-x: auto;
+    position: relative;
+    tab-size: 2;
+}
+.codeblock:before {
+    content: attr(data-gutter);
+    position: absolute;
+    background-color: #eee;
+    left: 0;
+    top: 0;
+    border-right: 1px solid #ccc;
+    padding: 8px;
+    color: #777;
+    white-space: pre-wrap;
+    text-align: right;
+    min-width: 25px;
+}
+
+.tokenComment {
+    color: slategray;
+}
+.tokenPunctuation {
+    color: #999;
+}
+.tokenProperty {
+    color: #905;
+}
+.tokenSelector {
+    color: #690;
+}
+.tokenOperator {
+    color: #9a6e3a;
+}
+.tokenAttr {
+    color: #07a;
+}
+.tokenVariable {
+    color: #e90;
+}
+.tokenFunction {
+    color: #dd4a68;
+}
+
+  
+  `;


### PR DESCRIPTION
## ✏️ 변경 요약

게시글 작성기 기능을 추가했습니다.

## 🔍 작업 내용

1. 링크 마크다운 단축키 추가
2. 코드 블럭 기능 추가
3. 코드 블럭 단축키 추가
4. PrivateRouter 관련 eslint 수정

## 📌 관련된 이슈

...

## 📢 기타

코드블럭 생성 방법 : backtick 3개 + 언어이름 + 스페이스바 => ` ```python ` 
코드블럭 탈출 방법 : `엔터 두 번` (최하단 빈 줄 2개면 탈출)
아직 코드블럭 추가 버튼은 안만들었습니다.

