### PR TITLE
게시글 이미지 업로드 방법 추가

### DIFF
--- a/src/components/features/Post/PostEditor.tsx
+++ b/src/components/features/Post/PostEditor.tsx
@@ -197,7 +197,7 @@ const EditorPlaceholder = styled.div`
   pointer-events: none;
   user-select: none;
   color: #ccc;
-  top: 18px;
+  top: 24px;
 `;
 
 const PostContainer = forwardRef<


### PR DESCRIPTION
## ✏️ 변경 요약

게시글 이미지 업로드를 더욱 편하게 하기 위해 방법들을 추가했습니다.

## 🔍 작업 내용

1. 사용자가 `ctrl + v`를 했을 때, 클립보드에서 이미지 파일 찾아서 이미지 노드 생성 후 커서 위치에 추가
2. 사용자가 이미지를 drop 했을 때, dataTransfer에서 이미지 파일 찾아서 이미지 노드 생성 후 돔의 가장 뒤에 추가

## 📌 관련된 이슈

...

## 📢 기타
