### PR TITLE
팀 주제 작성 및 수정 버튼 주제 불러오는 쿼리 추가

### DIFF
--- a/src/pages/TeamAdmin/TeamAdmin.tsx
+++ b/src/pages/TeamAdmin/TeamAdmin.tsx
@@ -27,9 +27,9 @@ import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
 import { updateAnnouncement } from '@/api/announcement';
 import {
   IArticle,
-  ITopicResponse,
   getArticlesByDate,
   getTeamInfoAndTags,
+  getTeamTopic,
 } from '@/api/dashboard';
 import announcementTodayIcon from '@/assets/TeamAdmin/announcementToday.svg';
 import AnnouncementIcon from '@/assets/TeamDashboard/announcement_purple.png';
@@ -38,7 +38,7 @@ import { colors } from '@/constants/colors';
 import { PATH } from '@/routes/path';
 import { currentViewAtom, selectedPostIdAtom } from '@/store/dashboard';
 import styled from '@emotion/styled';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
 
 const Grid = styled.div`
@@ -100,12 +100,10 @@ const SubjectControlButton: React.FC<{
   selectedDate: string;
 }> = ({ id, selectedDate }) => {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const data = queryClient.getQueryData([
-    'team-topic',
-    id,
-    selectedDate,
-  ]) as ITopicResponse;
+  const { data } = useQuery({
+    queryKey: ['team-topic', id, selectedDate],
+    queryFn: () => getTeamTopic(parseInt(id), selectedDate),
+  });
 
   return (
     <SubjectControlButtonWrap


### PR DESCRIPTION
## ✏️ 변경 요약

워래는 getQueryData를 통해 데이터를 가져왔는데 원래 쿼리 호출 부분과 달라 팀 주제를 불러오는 쿼리를 추가했습니다.

## 🔍 작업 내용

1. useQuery 직접 사용하도록 변경

## 📌 관련된 이슈

...

## 📢 기타
