### PR TITLE
팀 주제 캘린더 지난달 없어지던 부분 수정

### DIFF
--- a/src/pages/TeamAdmin/TeamAdmin.tsx
+++ b/src/pages/TeamAdmin/TeamAdmin.tsx
@@ -27,6 +27,7 @@ import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
 import { updateAnnouncement } from '@/api/announcement';
 import {
   IArticle,
+  ICalendarTag,
   getArticlesByDate,
   getTeamInfoAndTags,
   getTeamTopic,
@@ -203,6 +204,39 @@ export const TeamAdmin = () => {
 
   const [currentView, setCurrentView] = useAtom(currentViewAtom);
   const [selectedArticleId, setSelectedArticleId] = useAtom(selectedPostIdAtom);
+  //TODO: useCalendarTag
+  const [tags, setTags] = useState<ICalendarTag[]>([]);
+
+  const addTags = (newTags: ICalendarTag[]) => {
+    setTags((prevTags) => {
+      const updatedTags = [...prevTags];
+
+      newTags.forEach((newTag) => {
+        const existingIndex = updatedTags.findIndex(
+          (tag) => tag.subjectDate === newTag.subjectDate
+        );
+        if (existingIndex !== -1) {
+          updatedTags[existingIndex] = newTag;
+        } else {
+          updatedTags.push(newTag);
+        }
+      });
+
+      return updatedTags;
+    });
+  };
+
+  const { data: teamInfoData, isSuccess } = useQuery({
+    queryKey: ['team-info', id, year, month],
+    queryFn: () => getTeamInfoAndTags(Number(id), year, month),
+    enabled: !!id,
+  });
+
+  useEffect(() => {
+    if (isSuccess && teamInfoData) {
+      addTags(teamInfoData.subjectArticleDateAndTagResponses);
+    }
+  }, [isSuccess]);
 
   const { data: articlesData, dataUpdatedAt } = useQuery({
     queryKey: ['articles-by-date', id, selectedDate, page],
@@ -262,14 +296,7 @@ export const TeamAdmin = () => {
     }
   }, [show]);
 
-  const { data: teamInfoData } = useQuery({
-    queryKey: ['team-info', id, year, month],
-    queryFn: () => getTeamInfoAndTags(Number(id), year, month),
-    enabled: !!id,
-  });
-
   const announcementToday = teamInfoData?.myTeamResponse.teamAnnouncement || '';
-  const tags = teamInfoData?.subjectArticleDateAndTagResponses || [];
   const isTeamManager = teamInfoData?.teamManager ?? false;
 
   useLayoutEffect(() => {

--- a/src/pages/TeamAdmin/TeamAdmin.tsx
+++ b/src/pages/TeamAdmin/TeamAdmin.tsx
@@ -127,7 +127,7 @@ const SubjectControlButton: React.FC<{
         fontWeight={700}
         whiteSpace={'nowrap'}
       >
-        주제 작성 및 수정
+        {data?.articleId ? '주제 수정' : '주제 작성'}
       </SText>
     </SubjectControlButtonWrap>
   );


### PR DESCRIPTION
## ✏️ 변경 요약

## 🔍 작업 내용

1. 이제 캘린더 태그는 date를 기준으로 구분되며 계속 쌓입니다.
2. 팀장 페이지 주제 작성 및 수정 버튼 문구 `주제 작성` `주제 수정`으로 분리

## 📌 관련된 이슈

...

## 📢 기타
