### PR TITLE
위도우에서 화면 크기 breakpoint mobile 보다 작으면 스크롤바 숨김처리

### DIFF
--- a/src/components/commons/Container.tsx
+++ b/src/components/commons/Container.tsx
@@ -29,6 +29,11 @@ export const ContainerStyle = styled.div<ContainerProps>`
 
   @media (max-width: ${breakpoints.mobile}px) {
     padding: ${(props) => props.padding || '0 20px'};
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+    scrollbar-width: none;
   }
 `;
 

--- a/src/components/layout/CommonLayout.tsx
+++ b/src/components/layout/CommonLayout.tsx
@@ -1,3 +1,5 @@
+import { useWindowWidth } from '@/hooks/useWindowWidth';
+
 import { Container } from '@/components/commons/Container';
 import { Header } from '@/components/commons/Header';
 import { Alert } from '@/components/commons/Modal/Alert';
@@ -6,6 +8,7 @@ import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { setNavigator } from '@/api/apiInstance';
+import { breakpoints } from '@/constants/breakpoints';
 
 import { Confirm } from '../commons/Modal/Confirm';
 
@@ -35,8 +38,14 @@ export const CommonLayout: React.FC<{
     setNavigator(navigate);
   }, [navigate]);
 
+  const width = useWindowWidth();
+  const isMobile = width <= breakpoints.mobile;
+
   return (
-    <Container padding={'0'}>
+    <Container
+      padding={'0'}
+      scrollSnapType={isMobile ? 'y mandatory' : undefined}
+    >
       <Alert />
       <Confirm />
       <Header h={headerHeight} />

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -328,6 +328,15 @@ const ScrollSnapContainer = styled.div`
   overflow-y: auto;
   scroll-snap-type: y mandatory;
   position: relative;
+
+  @media (max-width: ${breakpoints.mobile}px) {
+    // 크롬 사파리
+    &::-webkit-scrollbar {
+      display: none;
+    }
+    // 파이어폭스
+    scrollbar-width: none;
+  }
 `;
 
 const ScrollStart = styled.div`


### PR DESCRIPTION
## ✏️ 변경 요약

css를 사용해 스크롤바를 안보이게 했습니다.

## 🔍 작업 내용

1. break point.mobile 상수 사용
2. &::-webkit-scrollbar, scrolbar-width, scroll-snap-type, overflow-y, height 사용

## 📌 관련된 이슈

...

## 📢 기타
