### PR TITLE
화면 헤더 아래에서 고정되던 부분 수정

### DIFF
--- a/src/components/layout/CommonLayout.tsx
+++ b/src/components/layout/CommonLayout.tsx
@@ -9,6 +9,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import { setNavigator } from '@/api/apiInstance';
 import { breakpoints } from '@/constants/breakpoints';
+import styled from '@emotion/styled';
 
 import { Confirm } from '../commons/Modal/Confirm';
 
@@ -48,8 +49,17 @@ export const CommonLayout: React.FC<{
     >
       <Alert />
       <Confirm />
+      <ScrollStart />
       <Header h={headerHeight} />
       {children}
     </Container>
   );
 };
+
+const ScrollStart = styled.div`
+  scroll-snap-align: start;
+
+  @media (max-width: ${breakpoints.mobile}px) {
+    margin-top: 50px;
+  }
+`;


### PR DESCRIPTION
## ✏️ 변경 요약
스크롤 관련 작업을 했습니다

## 🔍 작업 내용

1. 화면 헤더 아래에서 고정되던 부분 수정
2. 모바일 뷰일 때 컴퓨터에서도 상단 스프링 바운드 효과 추가


![ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/981edf11-9c92-4805-8743-ef59d0d3181a)

## 📌 관련된 이슈



## 📢 기타
