### PR TITLE
[1.0.5] 포스팅 툴바 레이아웃 수정

### DIFF
--- a/src/components/commons/Dropdown/Dropdown.tsx
+++ b/src/components/commons/Dropdown/Dropdown.tsx
@@ -6,6 +6,7 @@ import { createPortal } from 'react-dom';
 
 import dropdownIcon from '@/assets/Posting/dropdownIcon.svg';
 import styled from '@emotion/styled';
+import { breakpoints } from '@/constants/breakpoints';
 
 const dropDownPadding = 4;
 
@@ -13,6 +14,11 @@ const DropdownIcon = styled.img<{ isClicked?: boolean }>`
   width: 16px;
   margin-left: 8px;
   transform: ${(props) => (props.isClicked ? 'rotate(180deg)' : undefined)};
+
+  @media (max-width: ${breakpoints.mobile}px) {
+    width: 12px;
+    margin-left: 5px;
+  }
 `;
 
 export const Dropdown: React.FC<{

--- a/src/components/features/Post/plugins/ToolbarPlugin.tsx
+++ b/src/components/features/Post/plugins/ToolbarPlugin.tsx
@@ -216,7 +216,17 @@ export const ToolbarPlugin: React.FC<{
             </div>
             <HorizontalLine />
           </>
-        ) : null}
+        ) : (
+            <div
+              style={{
+                display: 'flex',
+                width: '100%',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <TemplateButton onClick={insertTemplate}>탬플릿</TemplateButton>
+            </div>
+            )}
 
         <div
           style={{
@@ -241,8 +251,9 @@ export const ToolbarPlugin: React.FC<{
           <div
             style={{
               display: 'flex',
-              width: '69px',
-              justifyContent: 'space-between',
+              width: '100%',
+              justifyContent: 'flex-end',
+              gap: '10px',
             }}
           >
             <button onClick={insertLink}>
@@ -353,6 +364,11 @@ const InsertIcon = styled.img<{ isSelected?: boolean }>`
   width: 20px;
   margin-left: 8px;
   border: ${(props) => (props.isSelected ? '1px solid #ccc' : undefined)};
+
+  @media (max-width: ${breakpoints.mobile}px) {
+    width: 16px;
+    margin-left: 5px;
+  }
 `;
 
 const TemplateButton = styled.button`

--- a/src/components/features/Post/segments/FontDropdown.tsx
+++ b/src/components/features/Post/segments/FontDropdown.tsx
@@ -190,6 +190,10 @@ const TextFlex = styled.div`
   display: flex;
   align-items: center;
   gap: 20px;
+
+  @media (max-width: ${breakpoints.mobile}px) {
+    gap: 10px;
+  }
 `;
 
 const TextFormatButton = styled.button<{
@@ -208,6 +212,6 @@ const TextFormatButton = styled.button<{
     textStyle === 'strikethrough' && 'text-decoration: line-through;'}
     
     @media (max-width: ${breakpoints.mobile}px) {
-    font-size: 16px;
+    font-size: 12px;
   }
 `;


### PR DESCRIPTION
## ✏️ 변경 요약

주제 작성하기 & 오늘의 글 작성하기 모바일 화면에서 이미지, 링크 입력 버튼 레이아웃 깨지는 부분 수정하였습니다.


## 🔍 작업 내용

<img width="284" alt="스크린샷 2025-02-27 오후 1 44 25" src="https://github.com/user-attachments/assets/5aec0734-9d76-4de8-840a-4017bdf4a829" />

1. 툴바 반응형 추가
2. 모바일에서 템플릿 버튼 안보이는 문제 수정

