### PR TITLE
[1.0.5] 캘린더 "오늘" 버튼 누르면 캘린더 상에서도 오늘이 선택되도록 수정

### DIFF
--- a/src/components/commons/Calendar/Calendar.tsx
+++ b/src/components/commons/Calendar/Calendar.tsx
@@ -1,6 +1,6 @@
 import { useWindowWidth } from '@/hooks/useWindowWidth';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 
@@ -51,6 +51,9 @@ export const CustomCalendar: React.FC<ICustomCalendarProps> = ({
   isPending = false,
 }) => {
   const [showPending, setShowPending] = useState(false);
+  const apiRef = useRef<{
+    onChange: (date: Date, e: React.MouseEvent<HTMLButtonElement>) => void;
+  } | null>(null);
 
   useEffect(() => {
     if (isPending) {
@@ -63,11 +66,11 @@ export const CustomCalendar: React.FC<ICustomCalendarProps> = ({
     }
   }, [isPending]);
 
-  const handleTodayClick = () => {
+  const handleTodayClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     const today = new Date();
-    const formattedToday = formatDate(today);
-
-    onDateSelect(formattedToday);
+    if (apiRef.current !== null) {
+      apiRef.current?.onChange(today, e);
+    }
   };
 
   const width = useWindowWidth();
@@ -81,6 +84,7 @@ export const CustomCalendar: React.FC<ICustomCalendarProps> = ({
       {showPending && <PendingState>정보를 가져오는 중…</PendingState>}
 
       <StyledCalendar
+        ref={apiRef}
         calendarType="gregory"
         formatDay={(_locale, date) => date.getDate().toString()}
         next2Label={null}
@@ -135,7 +139,7 @@ const CalendarWrapper = styled.div`
   }
 `;
 
-const StyledDate = styled.div`
+const StyledDate = styled.button`
   position: absolute;
   top: 16px;
   right: 20px;


### PR DESCRIPTION
## ✏️ 변경 요약

"오늘" 버튼 누르면 캘린더 상에서 오늘에 해당하는 날짜가 선택됩니다.

## 🔍 작업 내용

1. react-calendar 내부 코드 확인후 ref로 api들을 넣어주는거 확인후 사용했습니다.
2. 오늘 버튼을 눌러도 캘린더에서 날짜 선택하는거랑 똑같은 흐름으로 처리됩니다.

## 📌 관련된 이슈

...

## 📢 기타
