### PR TITLE
[1.0.5] 모바일 환경에서 헤더 내정보 안보이는 문제 해결

### DIFF
--- a/src/components/commons/Header.tsx
+++ b/src/components/commons/Header.tsx
@@ -213,7 +213,7 @@ export const Header: React.FC<HeightInNumber> = ({ h }) => {
       <Blur>
         <Flex
           align="center"
-          style={{ width: '396px' }}
+          style={{ width: isMobile ? '100%' : '396px' }}
           gap={isMobile ? '24px' : '80px'}
           height={24}
           padding={isMobile ? '' : '0 8px'}


### PR DESCRIPTION
## ✏️ 변경 요약

1. 모바일 환경에서 헤더 내 정보 버튼이 안보이는 문제를 해결했습니다. 
