### PR TITLE
feat: 팀 내 페이지 개인화 대시보드 구현 (프로필/주간 출석/연속·누적/잔디)

### DIFF
--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -36,6 +36,33 @@ export interface IArticlesByDateResponse {
   };
 }
 
+export type DayOfWeek =
+  | 'MONDAY'
+  | 'TUESDAY'
+  | 'WEDNESDAY'
+  | 'THURSDAY'
+  | 'FRIDAY'
+  | 'SATURDAY'
+  | 'SUNDAY';
+
+export interface IWeeklyGrassDay {
+  dayOfWeek: DayOfWeek;
+  count: number; // 그 요일의 풀이 글 수(원시값, 캡 없음)
+}
+
+export interface IDashboardResponse {
+  teamName: string;
+  nDays: number; // 추천 요일 수 (2 | 4 | 6)
+  joinedAt: string; // YYYY-MM-DD
+  imageUrl: string | null;
+  memberName: string;
+  description: string;
+  weeklySolvedDays: number; // 이번주 출석일수 A (A>B 가능, 클램핑 금지)
+  consecutiveSolveCount: number;
+  cumulativeSolveCount: number;
+  weeklyGrass: IWeeklyGrassDay[]; // 항상 월→일 순서로 7개
+}
+
 export interface ITopicResponse {
   articleId: number;
   articleCategory: string;
@@ -70,6 +97,16 @@ export const getArticlesByDate = async (
   const res = await apiInstance.get<ServerResponse<IArticlesByDateResponse>>(
     `/v1/articles/${teamId}/by-date`,
     { params: { date, page } }
+  );
+
+  return res.data.data;
+};
+
+export const getTeamDashboard = async (
+  teamId: number
+): Promise<IDashboardResponse> => {
+  const res = await apiInstance.get<ServerResponse<IDashboardResponse>>(
+    `/v1/teams/${teamId}/dashboard`
   );
 
   return res.data.data;

--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -52,7 +52,7 @@ export interface IWeeklyGrassDay {
 
 export interface IDashboardResponse {
   teamName: string;
-  nDays: number; // 추천 요일 수 (2 | 4 | 6)
+  nDays: number;
   joinedAt: string; // YYYY-MM-DD
   imageUrl: string | null;
   memberName: string;

--- a/src/components/features/TeamDashboard/PersonalDashboard.tsx
+++ b/src/components/features/TeamDashboard/PersonalDashboard.tsx
@@ -1,0 +1,37 @@
+import { Spacer } from '@/components/commons/Spacer';
+import { ProfileCard } from '@/components/features/TeamDashboard/ProfileCard';
+import { WeeklyGrass } from '@/components/features/TeamDashboard/WeeklyGrass';
+
+import { useTeamDashboard } from '@/hooks/useTeamDashboard';
+import styled from '@emotion/styled';
+
+interface IPersonalDashboardProps {
+  teamId?: string;
+  enabled: boolean; // 멤버일 때만 (비회원은 호출/렌더 안 함)
+}
+
+export const PersonalDashboard: React.FC<IPersonalDashboardProps> = ({
+  teamId,
+  enabled,
+}) => {
+  const { dashboard } = useTeamDashboard({ teamId, enabled });
+
+  if (!dashboard) {
+    return null;
+  }
+
+  return (
+    <Stack>
+      <ProfileCard data={dashboard} />
+      <Spacer h={20} />
+      <WeeklyGrass weeklyGrass={dashboard.weeklyGrass} nDays={dashboard.nDays} />
+    </Stack>
+  );
+};
+
+// Sidebar는 모바일에서 flex-row가 되므로, 카드들을 항상 세로로 고정
+const Stack = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;

--- a/src/components/features/TeamDashboard/ProfileCard.tsx
+++ b/src/components/features/TeamDashboard/ProfileCard.tsx
@@ -1,0 +1,240 @@
+import { Box } from '@/components/commons/Box';
+import { SText } from '@/components/commons/SText';
+import { Spacer } from '@/components/commons/Spacer';
+
+import { useEffect, useState } from 'react';
+import { RiInformationLine } from 'react-icons/ri';
+
+import { IDashboardResponse } from '@/api/dashboard';
+import DefaultProfile from '@/assets/TeamDashboard/default_profile.png';
+import { colors } from '@/constants/colors';
+import styled from '@emotion/styled';
+
+type ProfileCardData = Pick<
+  IDashboardResponse,
+  | 'imageUrl'
+  | 'memberName'
+  | 'nDays'
+  | 'description'
+  | 'weeklySolvedDays'
+  | 'consecutiveSolveCount'
+  | 'cumulativeSolveCount'
+>;
+
+const TOOLTIP = {
+  weekly: '이번 주동안 문제를 푼 날 수 / 추천된 문제 요일 수를 확인할 수 있어요.',
+  consecutive:
+    '추천 요일을 거르지 않고 이어서 푼 문제 수예요. 추천일에 안 풀면 초기화돼요.',
+  cumulative: '코몬에서 지금까지 푼 전체 문제 수예요.',
+};
+
+export const ProfileCard: React.FC<{ data: ProfileCardData }> = ({ data }) => {
+  const {
+    imageUrl,
+    memberName,
+    nDays,
+    description,
+    weeklySolvedDays,
+    consecutiveSolveCount,
+    cumulativeSolveCount,
+  } = data;
+
+  // 없거나 로드 실패 시 데모 이미지로 폴백
+  const [imgSrc, setImgSrc] = useState(imageUrl || DefaultProfile);
+  useEffect(() => {
+    setImgSrc(imageUrl || DefaultProfile);
+  }, [imageUrl]);
+
+  return (
+    <Box width="100%" padding="24px 20px" borderRadius="20px">
+      <Column>
+        <ProfileImage
+          src={imgSrc}
+          alt={memberName}
+          onError={() => setImgSrc(DefaultProfile)}
+          draggable={false}
+        />
+        <Spacer h={16} />
+        <SText fontSize="22px" fontWeight={700} color="#333" textAlign="center">
+          {memberName}
+        </SText>
+        <Spacer h={4} />
+        <SText fontSize="26px" fontWeight={800} color="#333" textAlign="center">
+          {nDays} DAYS
+        </SText>
+        <Spacer h={12} />
+        <SText
+          fontSize="14px"
+          fontWeight={400}
+          color="#777"
+          lineHeight="20px"
+          textAlign="center"
+        >
+          {description}
+        </SText>
+        <Spacer h={32} />
+
+        <StatItem label="이번 주" tip={TOOLTIP.weekly}>
+          <WeekNum>{weeklySolvedDays}</WeekNum>
+          <Slash>/</Slash>
+          <WeekNum>{nDays}</WeekNum>
+        </StatItem>
+
+        <Spacer h={12} />
+
+        <StatItem label="연속 풀이" tip={TOOLTIP.consecutive}>
+          <Fire>🔥</Fire>연속 <StatNum>{consecutiveSolveCount}</StatNum>문제 풀이
+        </StatItem>
+
+        <Spacer h={12} />
+
+        <StatItem label="누적 풀이" tip={TOOLTIP.cumulative}>
+          <Fire>🔥</Fire>누적 <StatNum>{cumulativeSolveCount}</StatNum>문제 풀이
+        </StatItem>
+      </Column>
+    </Box>
+  );
+};
+
+const InfoTip: React.FC<{ text: string }> = ({ text }) => (
+  <TipWrap tabIndex={0} aria-label={text}>
+    <RiInformationLine size={14} aria-hidden />
+    <Tip role="tooltip">{text}</Tip>
+  </TipWrap>
+);
+
+// 라벨 + ⓘ툴팁 + 값 박스 한 줄 (이번주/연속/누적 공통 구조)
+const StatItem: React.FC<{
+  label: string;
+  tip: string;
+  children: React.ReactNode;
+}> = ({ label, tip, children }) => (
+  <StatRow>
+    <StatLabel>
+      <LabelText>{label}</LabelText>
+      <InfoTip text={tip} />
+    </StatLabel>
+    <StatBox>{children}</StatBox>
+  </StatRow>
+);
+
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+// 정중앙 기준 크롭 → object-fit cover + 중앙 정렬
+const ProfileImage = styled.img`
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  object-position: center;
+  border-radius: 16px;
+  display: block;
+`;
+
+const StatRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+`;
+
+const StatLabel = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 14px;
+  font-weight: 600;
+  color: ${colors.buttonPurple};
+  margin-bottom: 6px;
+`;
+
+// 라벨 텍스트 고정폭 → ⓘ 아이콘이 모든 행에서 같은 x좌표(라벨 바로 옆)에 정렬됨
+const LabelText = styled.span`
+  display: inline-block;
+  width: 54px;
+`;
+
+// 세 박스 동일 폭/스타일 → 값 길이가 달라도 라벨/구조는 고정, 값만 바뀜
+const StatBox = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  background: ${colors.grassRecommendedBg};
+  border: 1px solid ${colors.borderPurple};
+  border-radius: 10px;
+  padding: 11px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+  white-space: nowrap;
+  letter-spacing: 0.3px;
+`;
+
+const Fire = styled.span`
+  margin-right: 8px;
+`;
+
+// 연속/누적: 숫자 영역 고정폭(우측정렬) → 자릿수가 달라도 숫자가 "문제 풀이"에 붙고 시작점도 일렬 정렬
+const StatNum = styled.span`
+  display: inline-block;
+  min-width: 32px;
+  text-align: right;
+  font-weight: 700;
+  color: ${colors.buttonPurple};
+  margin: 0 4px;
+`;
+
+// 이번 주: A/B는 고정폭 없이 타이트하게 ("4 / 2")
+const WeekNum = styled.span`
+  font-weight: 700;
+  color: ${colors.buttonPurple};
+`;
+
+// "/" 좌우 동일 여백 → 양옆 숫자 간격 대칭
+const Slash = styled.span`
+  margin: 0 5px;
+  color: #333;
+  font-weight: 500;
+`;
+
+const TipWrap = styled.span`
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  color: #b3b6cc;
+  cursor: help;
+  outline: none;
+
+  &:hover > div,
+  &:focus-within > div {
+    opacity: 1;
+    visibility: visible;
+  }
+`;
+
+const Tip = styled.div`
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: max-content;
+  max-width: 180px;
+  background: #333;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.5;
+  text-align: left;
+  white-space: normal;
+  padding: 6px 10px;
+  border-radius: 8px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.15s ease;
+  z-index: 20;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+`;

--- a/src/components/features/TeamDashboard/SidebarAndAnnouncement.tsx
+++ b/src/components/features/TeamDashboard/SidebarAndAnnouncement.tsx
@@ -6,6 +6,7 @@ import { Label } from '@/components/commons/Label';
 import { LazyImage } from '@/components/commons/LazyImage';
 import { SText } from '@/components/commons/SText';
 import { Spacer } from '@/components/commons/Spacer';
+import { PersonalDashboard } from '@/components/features/TeamDashboard/PersonalDashboard';
 
 import { Suspense, useState } from 'react';
 import { Toaster } from 'react-hot-toast';
@@ -100,6 +101,60 @@ export const SidebarAndAnnouncement: React.FC<ISidebarAndAnnouncementProps> = ({
     }
   };
 
+  const managerMenu = (
+    <Flex direction="column" justify="flex-start" align="flex-start">
+      <Link
+        to={`${PATH.TEAM_ADMIN}/${teamId}`}
+        style={{ textDecoration: 'none' }}
+        onClick={() => setSelectedId(null)}
+      >
+        <Flex justify="center" align="center">
+          <SettingImage src={SettingsGreenIcon} />
+          <SText
+            color="#ccc"
+            fontWeight={600}
+            fontSize={isMobile ? '10px' : '14px'}
+          >
+            게시글 관리
+          </SText>
+        </Flex>
+      </Link>
+      <Spacer h={2} />
+      <Link
+        to={`${PATH.TEAM_SETTING}/team/${teamId}`}
+        style={{ textDecoration: 'none' }}
+      >
+        <Flex justify={isMobile ? 'flex-start' : 'center'} align="center">
+          <SettingImage src={SettingsRedIcon} />
+          <SText
+            color="#ccc"
+            fontWeight={600}
+            fontSize={isMobile ? '10px' : '14px'}
+          >
+            팀 설정
+          </SText>
+        </Flex>
+      </Link>
+      <Spacer h={2} />
+      <Flex
+        width={'auto'}
+        justify={isMobile ? 'flex-start' : 'center'}
+        align="center"
+        onClick={handleClick}
+        style={{ cursor: 'pointer' }}
+      >
+        <SettingImage src={SettingsPurpleIcon} />
+        <SText
+          color="#ccc"
+          fontWeight={600}
+          fontSize={isMobile ? '10px' : '14px'}
+        >
+          모집글
+        </SText>
+      </Flex>
+    </Flex>
+  );
+
   return (
     <>
       <Toaster
@@ -110,7 +165,21 @@ export const SidebarAndAnnouncement: React.FC<ISidebarAndAnnouncementProps> = ({
         }}
       />
       <Sidebar>
-        <Box
+        {isMyTeam ? (
+          <MemberSidebar>
+            <PersonalDashboard teamId={teamId} enabled={isMyTeam} />
+            {isTeamManager && (
+              <>
+                <Spacer h={20} />
+                <Box width="100%" padding="16px 24px" borderRadius="20px">
+                  {managerMenu}
+                </Box>
+              </>
+            )}
+          </MemberSidebar>
+        ) : (
+          <>
+            <Box
           width={isMobile ? '84px' : '100%'}
           height={isMobile ? '84px' : '260px'}
           borderWidth={isMobile ? '1px' : '3px'}
@@ -217,69 +286,12 @@ export const SidebarAndAnnouncement: React.FC<ISidebarAndAnnouncementProps> = ({
                   <Spacer h={4} />
                 </>
               )}
-              {isTeamManager && (
-                <Flex
-                  direction="column"
-                  justify="flex-start"
-                  align="flex-start"
-                >
-                  <Link
-                    to={`${PATH.TEAM_ADMIN}/${teamId}`}
-                    style={{ textDecoration: 'none' }}
-                    onClick={() => setSelectedId(null)}
-                  >
-                    <Flex justify="center" align="center">
-                      <SettingImage src={SettingsGreenIcon} />
-                      <SText
-                        color="#ccc"
-                        fontWeight={600}
-                        fontSize={isMobile ? '10px' : '14px'}
-                      >
-                        게시글 관리
-                      </SText>
-                    </Flex>
-                  </Link>
-                  <Spacer h={2} />
-                  <Link
-                    to={`${PATH.TEAM_SETTING}/team/${teamId}`}
-                    style={{ textDecoration: 'none' }}
-                  >
-                    <Flex
-                      justify={isMobile ? 'flex-start' : 'center'}
-                      align="center"
-                    >
-                      <SettingImage src={SettingsRedIcon} />
-                      <SText
-                        color="#ccc"
-                        fontWeight={600}
-                        fontSize={isMobile ? '10px' : '14px'}
-                      >
-                        팀 설정
-                      </SText>
-                    </Flex>
-                  </Link>
-                  <Spacer h={2} />
-                  <Flex
-                    width={'auto'}
-                    justify={isMobile ? 'flex-start' : 'center'}
-                    align="center"
-                    onClick={handleClick}
-                    style={{ cursor: 'pointer' }}
-                  >
-                    <SettingImage src={SettingsPurpleIcon} />
-                    <SText
-                      color="#ccc"
-                      fontWeight={600}
-                      fontSize={isMobile ? '10px' : '14px'}
-                    >
-                      모집글
-                    </SText>
-                  </Flex>
-                </Flex>
-              )}
+              {isTeamManager && managerMenu}
             </div>
           </Flex>
         </Box>
+          </>
+        )}
       </Sidebar>
 
       <Announcement>
@@ -363,6 +375,13 @@ const Sidebar = styled.aside`
     display: flex;
     gap: 4px;
   }
+`;
+
+// 멤버용 개인화 영역: Sidebar가 모바일에서 flex-row가 되므로 단일 컬럼으로 고정
+const MemberSidebar = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
 `;
 
 const ImageContainer = styled(LazyImage)`

--- a/src/components/features/TeamDashboard/WeeklyGrass.tsx
+++ b/src/components/features/TeamDashboard/WeeklyGrass.tsx
@@ -1,0 +1,95 @@
+import { Box } from '@/components/commons/Box';
+
+import { DayOfWeek, IWeeklyGrassDay } from '@/api/dashboard';
+import { colors } from '@/constants/colors';
+import styled from '@emotion/styled';
+
+const ROWS = 4; // 한 요일(열)은 세로 최대 4칸
+const DAY_ORDER: DayOfWeek[] = [
+  'MONDAY',
+  'TUESDAY',
+  'WEDNESDAY',
+  'THURSDAY',
+  'FRIDAY',
+  'SATURDAY',
+  'SUNDAY',
+];
+
+// 추천 요일(강조) index 집합 — 좌→우 월(0)~일(6) 기준
+const getRecommendedDayIndexes = (nDays: number): Set<number> => {
+  switch (nDays) {
+    case 2:
+      return new Set([1, 3]); // 화·목
+    case 4:
+      return new Set([0, 1, 2, 3]); // 월~목
+    case 6:
+      return new Set([0, 1, 2, 3, 4, 5]); // 일 제외 전부
+    default:
+      return new Set<number>();
+  }
+};
+
+interface IWeeklyGrassProps {
+  weeklyGrass: IWeeklyGrassDay[];
+  nDays: number;
+}
+
+export const WeeklyGrass: React.FC<IWeeklyGrassProps> = ({
+  weeklyGrass,
+  nDays,
+}) => {
+  const recommended = getRecommendedDayIndexes(nDays);
+
+  // 응답은 항상 월→일 7개지만, 순서를 신뢰하지 않고 요일 기준으로 정렬
+  const countByDay = new Map<DayOfWeek, number>(
+    weeklyGrass.map((d) => [d.dayOfWeek, d.count])
+  );
+  const columns = DAY_ORDER.map((day) => countByDay.get(day) ?? 0);
+
+  return (
+    <Box width="100%" padding="20px 16px" borderRadius="20px">
+      <Grid>
+        {columns.map((count, colIndex) => {
+          const isRecommended = recommended.has(colIndex);
+          const filled = Math.min(count, ROWS); // 4 초과여도 최대 4칸
+          return (
+            <Column key={colIndex}>
+              {Array.from({ length: ROWS }).map((_, rowIndex) => (
+                <Cell
+                  key={rowIndex}
+                  isFilled={rowIndex < filled}
+                  isRecommended={isRecommended}
+                />
+              ))}
+            </Column>
+          );
+        })}
+      </Grid>
+    </Box>
+  );
+};
+
+const Grid = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 6px;
+  width: 100%;
+`;
+
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+`;
+
+const Cell = styled.div<{ isFilled: boolean; isRecommended: boolean }>`
+  aspect-ratio: 1 / 1;
+  border-radius: 4px;
+  background: ${({ isFilled, isRecommended }) =>
+    isFilled
+      ? colors.grassFilled
+      : isRecommended
+        ? colors.grassRecommendedBg
+        : colors.grassDefaultBg};
+`;

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -3,4 +3,7 @@ export const colors = {
   buttonPink: '#F15CA7',
   borderPurple: '#CDCFFF',
   headerPurple: '#F0F1FF',
+  grassFilled: '#8488EC', // 잔디 채운 칸 (= buttonPurple)
+  grassRecommendedBg: '#EFF0FF', // 추천 요일 칸 배경
+  grassDefaultBg: '#F8F8FF', // 비추천 요일 칸 배경
 };

--- a/src/hooks/useTeamDashboard.ts
+++ b/src/hooks/useTeamDashboard.ts
@@ -1,0 +1,17 @@
+import { getTeamDashboard } from '@/api/dashboard.ts';
+import { useQuery } from '@tanstack/react-query';
+
+type UseTeamDashboardArg = {
+  teamId?: string;
+  enabled: boolean; // 멤버일 때만 호출 (비회원 호출 시 서버 에러)
+};
+
+export const useTeamDashboard = ({ teamId, enabled }: UseTeamDashboardArg) => {
+  const { data } = useQuery({
+    queryKey: ['team-dashboard', teamId],
+    queryFn: () => getTeamDashboard(Number(teamId)),
+    enabled: !!teamId && enabled,
+  });
+
+  return { dashboard: data ?? null };
+};


### PR DESCRIPTION
## 개요
  팀 내 페이지를 팀 정보 중심 → 개인 맞춤(습관화/동기부여)으로 개편하는 Phase 1(개인화) 구현.
  멤버에게 좌측 영역에 프로필 카드 + 주간 잔디를 노출합니다.

  - `GET /api/v1/teams/{teamId}/dashboard` 연동 + 응답 타입(`IDashboardResponse`/`IWeeklyGrassDay`)
  - `useTeamDashboard` 훅 (멤버일 때만 호출 — `isMyTeam` 게이팅)
  - 컴포넌트: `PersonalDashboard`(컨테이너) / `ProfileCard`(이미지·이름·N DAYS·소개·이번주
  A·B·연속·누적) / `WeeklyGrass`(7×4 잔디)
  - `SidebarAndAnnouncement`: 멤버=개인화 / 비회원=기존 팀정보 분기 (공지·매니저 메뉴 유지)
  - 잔디 색상 토큰 추가
 
  ## 규칙
  - 이번주 A/B = `weeklySolvedDays / nDays`, **A>B 가능(클램핑 없음)**
  - 잔디: 월→일 7열, 열당 위→아래 최대 4칸(초과 cap), 추천요일 강조(nDays 2/4/6)
  - 누적=전체 팀·전기간, 연속=백엔드 계산값 표시, 프로필 이미지 없음/로드실패 시 데모 이미지

  ## 범위
  Phase 1만. Phase 2(주간화)·3(소통화)·기존 월간 캘린더는 그대로.

  ## 테스트
  RDS 데이터 주입 시각 검증: A/B(A>B 포함)·잔디 4칸 cap·nDays 2/4/6 강조·연속 streak·누적·이미지 폴백 통과.